### PR TITLE
Fix Permission Issue for Cache Directory in Node Modules

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,20 +1,23 @@
-# pull official base image
+# Pull official base image
 FROM node:16-slim
 
-# set work directory
+# Set working directory
 WORKDIR /srv/app/frontend
 
-# add to $PATH
-ENV PATH /srv/app/node_modules/.bin:$PATH
+# Add to $PATH
+ENV PATH /srv/app/frontend/node_modules/.bin:$PATH
 
-# install app dependencies
-COPY package.json ./
-COPY package-lock.json ./
-RUN npm install react-scripts@3.4.1 -g --silent
-RUN npm install
+# Copy package.json and package-lock.json first to leverage Docker cache
+COPY package.json package-lock.json ./
 
-# add app
-COPY . ./
+# Install app dependencies and create necessary directories with permissions
+RUN npm install react-scripts@3.4.1 -g --silent && \
+    npm install && \
+    mkdir -p /srv/app/frontend/node_modules/.cache && \
+    chmod -R 777 /srv/app/frontend/node_modules/.cache
 
-# Start app
+# Copy the rest of the application code
+COPY . .
+
+# Start the app
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary

This PR addresses a permission issue that was causing the application to fail when creating cache files in the `node_modules/.cache` directory. By ensuring appropriate permissions and restructuring the Dockerfile, we can avoid these errors and improve the application's reliability during the build and runtime processes.

## Changes Made

### Corrected Directory Paths and Permissions

- Updated the Dockerfile to explicitly create and set permissions for the `node_modules/.cache` directory using:
  ```dockerfile
  RUN mkdir -p /srv/app/frontend/node_modules/.cache && \
      chmod -R 777 /srv/app/frontend/node_modules/.cache
  ```
  This ensures that the cache directory has the necessary write permissions during build and runtime.

### Improved Dockerfile Efficiency

- Reordered Dockerfile steps to maximize layer caching, speeding up rebuilds by copying only `package.json` and `package-lock.json` initially.

### Updated Path in Environment Variables

- Ensured the `ENV PATH` variable correctly points to `/srv/app/frontend/node_modules/.bin`.